### PR TITLE
Make useAckee SSR-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ useAckee('/current/path', {
 
 Ackee will create a new record every time the `pathname` changes. An undefined or empty `pathname` will be skipped. Use `/` for the root instead.
 
+This hook is a no-op on the server for safe usage during server-side rendering.
+
 ## API
 
 ### Parameters

--- a/src/index.js
+++ b/src/index.js
@@ -6,16 +6,21 @@ const ackeeTracker = require('ackee-tracker')
 /**
  * Use Ackee in React.
  * Creates an instance once and a new record every time the pathname changes.
+ * Safely no-ops during server-side rendering.
  * @param {?String} pathname - Current path.
  * @param {Object} environment - Object containing the URL of the Ackee server and the domain id.
  * @param {?Object} options - Ackee options.
  */
 const useAckee = function(pathname, environment, options = {}) {
 	const instance = useMemo(() => {
+		if (typeof window === 'undefined') return null
+
 		return ackeeTracker.create(environment.server, options)
 	}, [ environment.server, options.detailed, options.ignoreLocalhost, options.ignoreOwnVisits ])
 
 	useEffect(() => {
+		if (!instance) return
+
 		const hasPathname = (
 			pathname != null &&
 			pathname !== ''


### PR DESCRIPTION
`ackeeTracker.create()` can't be naively called in isomorphic code because it directly reaches out to browser APIs ([location](https://github.com/electerious/ackee-tracker/blob/master/src/scripts/main.js#L283), [navigator](https://github.com/electerious/ackee-tracker/blob/master/src/scripts/main.js#L288), etc), resulting in things like `ReferenceError: location is not defined`. For projects that use `ackee-tracker` directly, they can more easily conditionally call the constructor. But this problem is harder to deal with for consumers of `useAckee` since you're not supposed to conditionally call hooks, making it more appropriate for the library itself to deal with handling the server-vs-client distinctions. This manifests in issues like #8 where users would instead have to get into conditionally rendering or dynamically importing a tracking component (or breaking the rules of hooks).

This change short-circuits the creation of the ackee tracker instance in `useMemo` for non-browser environments. `useEffect` only runs in the browser so it should not ever actually encounter `instance === null`, but I included a safety check in the `useEffect` body anyway in case things change in a future version of React.

I've tested this working with `useAckee` running in `_app.js` in a Next project.