### PR TITLE
Adding support for React v18 and v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^17.0.1"
   },
   "peerDependencies": {
-    "react": "^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
As mentioned in this comment https://github.com/electerious/use-ackee/pull/12#issuecomment-1619842093 ideally we should be supporting v16 as-well. Additionally adding support for v18.
Consciously not adding for future versions and being very specific.  

npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: nobelium@1.3.0
npm ERR! Found: react@18.3.1
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.0" from use-ackee@3.0.1
npm ERR! node_modules/use-ackee
npm ERR!   use-ackee@"^3.0.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! /Users/****/.npm/_logs/2024-06-13T07_57_03_173Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/****/.npm/_logs/2024-06-13T07_57_03_173Z-debug-0.log